### PR TITLE
Improvement/stop logic

### DIFF
--- a/src/AgentModel.cpp
+++ b/src/AgentModel.cpp
@@ -188,8 +188,6 @@ void AgentModel::decisionProcessStop() {
 
     for(auto &e : _input.signals) 
     {
-        if (e.id == agent_model::NOS) continue;
-
         if (e.type == agent_model::SignalType::SIGNAL_TLS && 
             e.ds >= 0 && e.ds < ds_rel_tls) 
         {

--- a/src/AgentModel.cpp
+++ b/src/AgentModel.cpp
@@ -288,6 +288,10 @@ void AgentModel::decisionProcessStop() {
 
     // if not yet decided to drive or stop -> consider targets
     if (!drive && !stop) {   
+
+        // ignore if not approaching intersection
+        if (_input.vehicle.dsIntersection == INFINITY)
+            return;
         
         // ignore if on priority lane and driving straight (or right - for now)
         if (_state.conscious.stop.priority && 
@@ -303,6 +307,10 @@ void AgentModel::decisionProcessStop() {
 
             // ignore targets not in junction area
             if (t.position == agent_model::TARGET_NOT_RELEVANT) 
+                continue;
+                
+            // ignore targets on path
+            if (t.position == agent_model::TARGET_ON_PATH) 
                 continue;
 
             // ego is on priority
@@ -353,12 +361,18 @@ void AgentModel::decisionProcessStop() {
                         stop = true;
                         continue;
                     }
-                    
-                    // right target and right turn -> continue
-                    else if (t.position == agent_model::TARGET_ON_RIGHT && _input.vehicle.maneuver == agent_model::Maneuver::TURN_RIGHT)
+                       
+                    // opposite target and not left turn -> continue
+                    if (t.position == agent_model::TARGET_ON_OPPOSITE && _input.vehicle.maneuver != agent_model::Maneuver::TURN_LEFT)
                     {
                         continue;
                     }
+
+                    // right target and right turn -> continue
+                    if (t.position == agent_model::TARGET_ON_RIGHT && _input.vehicle.maneuver == agent_model::Maneuver::TURN_RIGHT)
+                    {
+                        continue;
+                    }                 
 
                     // if no special case, check if ego reaches junction earlier
                     if (_input.vehicle.dsIntersection / _input.vehicle.v < t.dsIntersection / t.v) 

--- a/src/AgentModel.cpp
+++ b/src/AgentModel.cpp
@@ -323,6 +323,13 @@ void AgentModel::decisionProcessStop() {
             // ego is on give way lane
             if (_state.conscious.stop.give_way)
             {
+                // stop for target already on intersection
+                if (t.position == agent_model::TargetPosition::TARGET_ON_INTERSECTION)
+                {
+                    stop = true;
+                    continue;
+                }
+
                 // stop if target prority not set (passive behavior)
                 if (t.priority == agent_model::TargetPriority::TARGET_PRIORITY_NOT_SET) 
                 {
@@ -335,7 +342,7 @@ void AgentModel::decisionProcessStop() {
                 {   
                     // special cases
 
-                    // opposite taget and left turn -> stop
+                    // opposite target and left turn -> stop
                     if (t.position == agent_model::TARGET_ON_OPPOSITE && _input.vehicle.maneuver == agent_model::Maneuver::TURN_LEFT)
                     {
                         if (_input.vehicle.maneuver == agent_model::Maneuver::TURN_LEFT)
@@ -362,13 +369,6 @@ void AgentModel::decisionProcessStop() {
                     }
                 }
 
-                // stop for target already on intersection
-                if (t.priority == agent_model::TargetPriority::TARGET_ON_INTERSECTION)
-                {
-                    stop = true;
-                    continue;
-                }
-
                 // stop for target on priority lane
                 if (t.priority == agent_model::TargetPriority::TARGET_ON_PRIORITY_LANE)
                 {
@@ -380,7 +380,7 @@ void AgentModel::decisionProcessStop() {
             // ego is not on priority and give way lane (right before left)
             if (!_state.conscious.stop.priority && !_state.conscious.stop.give_way) 
             {
-                if (t.position == agent_model::TARGET_ON_JUNCTION)
+                if (t.position == agent_model::TARGET_ON_INTERSECTION)
                 {
                     stop = true;
                     continue;

--- a/src/AgentModel.cpp
+++ b/src/AgentModel.cpp
@@ -184,8 +184,8 @@ void AgentModel::decisionProcessStop() {
         if ((e.type == agent_model::SignalType::SIGNAL_YIELD ||
             e.type == agent_model::SignalType::SIGNAL_PRIORITY ||
             e.type == agent_model::SignalType::SIGNAL_STOP) && 
-            rel->sign_is_in_use &&
-            !rel->subsignal &&
+            e.sign_is_in_use &&
+            !e.subsignal &&
             e.ds >= 0 && e.ds < ds_rel_sgn) 
         {
             ds_rel_sgn = e.ds;

--- a/src/AgentModel.cpp
+++ b/src/AgentModel.cpp
@@ -305,7 +305,7 @@ void AgentModel::decisionProcessStop() {
             if (t.position == agent_model::TARGET_NOT_RELEVANT) 
                 continue;
 
-            // ego is on priority lane and turns left
+            // ego is on priority
             if (_state.conscious.stop.priority)
             {   
                 // normaly do not stop when on priority lane

--- a/src/AgentModel.cpp
+++ b/src/AgentModel.cpp
@@ -163,9 +163,9 @@ void AgentModel::decisionProcessStop() {
     // add stop point because of destination point
     if (_input.signals[agent_model::NOS-1].id == agent_model::NOS)
     {
-        _state.decisions.stopping[agent_model::NOS-1].id = agent_model::NOS;
-        _state.decisions.stopping[agent_model::NOS-1].position = _input.vehicle.s + _input.signals[agent_model::NOS-1].ds;
-        _state.decisions.stopping[agent_model::NOS-1].standingTime = INFINITY;
+        _state.decisions.stopping[2].id = agent_model::NOS;
+        _state.decisions.stopping[2].position = _input.vehicle.s + _input.signals[agent_model::NOS-1].ds;
+        _state.decisions.stopping[2].standingTime = INFINITY;
     }
 
     // not yet decided about to stop or drive
@@ -205,7 +205,7 @@ void AgentModel::decisionProcessStop() {
     }
 
     // take closest signal (take traffic light even if 10 meters behind sign)
-    if (ds_rel_tls <= ds_rel_sgn+10) {
+    if (ds_rel_tls <= ds_rel_sgn + 10) {
         rel = rel_tls;
     } else {
         rel = rel_sgn;
@@ -350,7 +350,7 @@ void AgentModel::decisionProcessStop() {
                     }
 
                     // if no special case, check if ego reaches junction earlier
-                    if (rel->ds / _input.vehicle.v < t.dsIntersection / t.v) 
+                    if (_input.vehicle.dsIntersection / _input.vehicle.v < t.dsIntersection / t.v) 
                     {
                         continue;
                     } 
@@ -410,8 +410,9 @@ void AgentModel::decisionProcessStop() {
         // add stop point because of target
         if (stop)
         {
+            // try to stop 10m before intersection
             double ds_stop = std::max(0.0, _input.vehicle.dsIntersection - 10);
-            _state.decisions.stopping[1].id = agent_model::NOS + 1; //convention
+            _state.decisions.stopping[1].id = -1;
             _state.decisions.stopping[1].position = _input.vehicle.s + ds_stop;
             _state.decisions.stopping[1].standingTime = _param.stop.tSign;
         }

--- a/src/Interface.h
+++ b/src/Interface.h
@@ -127,6 +127,7 @@ namespace agent_model {
         double egoLaneWidth[NOH]; //!< Width of the ego lane (in *m*)
         double rightLaneWidth[NOH]; //!< Width of the right lane (in *m*)
         double leftLaneWidth[NOH]; //!< Width of the left lane (in *m*)
+        double destinationPoint; //!< s coordinate of destination point (in *m*)
     };
 
     /*!< A class to store lane information. */
@@ -188,7 +189,9 @@ namespace agent_model {
     struct Decisions {
         int laneChange; //!< The decision to perform a lane change. The sign defines the direction. The value defines the number of lanes to be changed.
         Point lateral; //!< The decision to move to a defined lateral offset within a defined distance or time (mode=0: distance, mode=1: time).
-        DecisionStopping stopping[3]; //!< The decision information for a stop. Stop could be due to signal, target or destination point.
+        DecisionStopping signal; //!< The decision information caused by a signal.
+        DecisionStopping target; //!< The decision information caused by a target.
+        DecisionStopping destination; //!< The decision information caused by a destination.
     };
 
     /*!< A class to store the internal state for the conscious&#x2F;velocity component. */

--- a/src/Interface.h
+++ b/src/Interface.h
@@ -59,7 +59,7 @@ namespace agent_model {
     enum TargetPriority { TARGET_ON_INTERSECTION, TARGET_ON_PRIORITY_LANE, TARGET_ON_GIVE_WAY_LANE, TARGET_PRIORITY_NOT_SET };
 
     /*!< This enum describes the priority of a target. */
-    enum TargetPosition { TARGET_NOT_RELEVANT, TARGET_ON_JUNCTION, TARGET_ON_OPPOSITE, TARGET_ON_RIGHT, TARGET_ON_LEFT };
+    enum TargetPosition { TARGET_NOT_RELEVANT, TARGET_ON_PATH, TARGET_ON_JUNCTION, TARGET_ON_OPPOSITE, TARGET_ON_RIGHT, TARGET_ON_LEFT };
 
     /*!< This enum describes the maneuver performed by the host. */
     enum Maneuver { STRAIGHT, TURN_LEFT, TURN_RIGHT };
@@ -113,6 +113,8 @@ namespace agent_model {
         double pedal; //!< The actual pedal value [-1..1]. Negative values define a brake pedal
         double steering; //!< The actual steering value [-1..1]. Negative values define left turns
         Maneuver maneuver; //!< The general classification of the vehicle's path during the scenario
+        double dsIntersection; //!< Distance along s to the intersection (if ego is approaching an intersection)
+
     };
 
     /*!< A class to store horizon points. */

--- a/src/Interface.h
+++ b/src/Interface.h
@@ -56,7 +56,10 @@ namespace agent_model {
     enum TrafficLightIcon { ICON_OTHER, ICON_NONE, ICON_ARROW_STRAIGHT_AHEAD, ICON_ARROW_LEFT, ICON_ARROW_RIGHT }; 
 
     /*!< This enum describes the priority of a target. */
-    enum TargetPriority { TARGET_ON_INTERSECTION, TARGET_ON_PRIORITY_LANE, TARGET_ON_GIVE_WAY_LANE, TARGET_PRIORITY_NOT_SET};
+    enum TargetPriority { TARGET_ON_INTERSECTION, TARGET_ON_PRIORITY_LANE, TARGET_ON_GIVE_WAY_LANE, TARGET_PRIORITY_NOT_SET };
+
+    /*!< This enum describes the priority of a target. */
+    enum TargetPosition { TARGET_NOT_RELEVANT, TARGET_ON_JUNCTION, TARGET_ON_OPPOSITE, TARGET_ON_RIGHT, TARGET_ON_LEFT };
 
     /*!< This enum describes the maneuver performed by the host. */
     enum Maneuver { STRAIGHT, TURN_LEFT, TURN_RIGHT };
@@ -169,6 +172,7 @@ namespace agent_model {
         Dimensions size; //!< Width and length of the target.
         double dsIntersection; //!< Distance along s to the intersection (if target is approaching an intersection)
         TargetPriority priority; //!< Priority of the target's lane. Used to determine right of way.
+        TargetPosition position; //!< Area in junction of target. Used to determine right of way.
     };
 
     /*!< A class to store the internal state for the decision&#x2F;stopping component. */

--- a/src/Interface.h
+++ b/src/Interface.h
@@ -127,7 +127,7 @@ namespace agent_model {
         double egoLaneWidth[NOH]; //!< Width of the ego lane (in *m*)
         double rightLaneWidth[NOH]; //!< Width of the right lane (in *m*)
         double leftLaneWidth[NOH]; //!< Width of the left lane (in *m*)
-        double destinationPoint; //!< s coordinate of destination point (in *m*)
+        double destinationPoint; //!< s coordinate of destination point (in *m*) -1 if not set
     };
 
     /*!< A class to store lane information. */

--- a/src/Interface.h
+++ b/src/Interface.h
@@ -188,7 +188,7 @@ namespace agent_model {
     struct Decisions {
         int laneChange; //!< The decision to perform a lane change. The sign defines the direction. The value defines the number of lanes to be changed.
         Point lateral; //!< The decision to move to a defined lateral offset within a defined distance or time (mode=0: distance, mode=1: time).
-        DecisionStopping stopping[NOS]; //!< The decision information for a stop.
+        DecisionStopping stopping[3]; //!< The decision information for a stop. Stop could be due to signal, target or destination point.
     };
 
     /*!< A class to store the internal state for the conscious&#x2F;velocity component. */

--- a/src/Interface.h
+++ b/src/Interface.h
@@ -156,8 +156,6 @@ namespace agent_model {
         TrafficLightColor color; //!< Color of the light bulb.
         TrafficLightIcon icon; //!< Icon/Shape of the traffic light.
         bool subsignal;     //!< if true sign is subsignal to TLS and only valid in certain situations
-        bool is_out_of_service; //!< indicates that TLS is out of service if true
-        int pairedSignalID[3]; //!< Subsignals are paired to 3 Light IDs
         bool sign_is_in_use;   //!< indicates that subsign is in use (all paired TLS signals are out of service)
     };
 

--- a/src/Interface.h
+++ b/src/Interface.h
@@ -196,6 +196,8 @@ namespace agent_model {
         double ds; //!< The actual distance to the stop point. (in *m*)
         double dsMax; //!< The reference distance at which the driver decides to stop (in *m*)
         bool standing; //!< A flag to define if the driver has stopped for the desired stop.
+        bool priority; //!< A flag to define if the driver drives on a priority lane.
+        bool give_way; //!< A flag to define if the driver drives on a give way lane.
     };
 
     /*!< A class to store the internal state for the conscious&#x2F;follow component. */

--- a/src/Interface.h
+++ b/src/Interface.h
@@ -56,10 +56,10 @@ namespace agent_model {
     enum TrafficLightIcon { ICON_OTHER, ICON_NONE, ICON_ARROW_STRAIGHT_AHEAD, ICON_ARROW_LEFT, ICON_ARROW_RIGHT }; 
 
     /*!< This enum describes the priority of a target. */
-    enum TargetPriority { TARGET_ON_INTERSECTION, TARGET_ON_PRIORITY_LANE, TARGET_ON_GIVE_WAY_LANE, TARGET_PRIORITY_NOT_SET };
+    enum TargetPriority { TARGET_ON_PRIORITY_LANE, TARGET_ON_GIVE_WAY_LANE, TARGET_PRIORITY_NOT_SET };
 
     /*!< This enum describes the priority of a target. */
-    enum TargetPosition { TARGET_NOT_RELEVANT, TARGET_ON_PATH, TARGET_ON_JUNCTION, TARGET_ON_OPPOSITE, TARGET_ON_RIGHT, TARGET_ON_LEFT };
+    enum TargetPosition { TARGET_NOT_RELEVANT, TARGET_ON_PATH, TARGET_ON_INTERSECTION, TARGET_ON_OPPOSITE, TARGET_ON_RIGHT, TARGET_ON_LEFT };
 
     /*!< This enum describes the maneuver performed by the host. */
     enum Maneuver { STRAIGHT, TURN_LEFT, TURN_RIGHT };

--- a/src/StopHorizon.h
+++ b/src/StopHorizon.h
@@ -94,9 +94,10 @@ namespace agent_model {
                 _elements[id].passed = true;
                 return true;
             }
-            // only add if not already added - replace stop point from now on
-            //if(_elements.find(id) != _elements.end())
-            //    return false;
+            // only add if not already added
+            if(_elements.find(id) != _elements.end())
+                if (fabs(_elements[id].s - sStop) < 0.5)
+                    return false;
 
             // only add when distance is large enough
             if(_sActual - sStop >= DELETE_AFTER_DISTANCE - EPS_DISTANCE)

--- a/src/StopHorizon.h
+++ b/src/StopHorizon.h
@@ -106,7 +106,7 @@ namespace agent_model {
             _elements[id] = {sStop, _sActual, INFINITY, standingTime, false};
 
             return true;
-
+            
         }
 
 

--- a/src/StopHorizon.h
+++ b/src/StopHorizon.h
@@ -94,9 +94,9 @@ namespace agent_model {
                 _elements[id].passed = true;
                 return true;
             }
-            // only add if not already added
-            if(_elements.find(id) != _elements.end())
-                return false;
+            // only add if not already added - replace stop point from now on
+            //if(_elements.find(id) != _elements.end())
+            //    return false;
 
             // only add when distance is large enough
             if(_sActual - sStop >= DELETE_AFTER_DISTANCE - EPS_DISTANCE)


### PR DESCRIPTION
- Destination Point is included in `horizon.destinationPoint`
- `_state.decisions.stoppings` is replaced by `_state.decisions.signal`, `_state.decisions.target`  and `_state.decisions.destination -> three different reasons for stopping can exist and therefore maximal three stop points exist.
- ID of stop points is 1 (caused by signal), 2 (caused by target), 3 (caused by destination)
- ego vehicles priority status is stored in ` _state.conscious.stop.priority`

Completely new structure of decisionStop():
- first check for signals and save priority information
- then check for targets(ego on priority, ego on yielding, else (right before left rule) - here target position information are used)
- (in addition, also static destination points could exist)
